### PR TITLE
fix: CONTROL_REGISTRY_PATH broken on macOS/Linux

### DIFF
--- a/src/fjml/constants.py
+++ b/src/fjml/constants.py
@@ -7,7 +7,7 @@ MODULE_PATH: str = Path.PurePath(__file__).parent
 OPERATION_ARGS: Final[Sequence[str]] = ["make", "registry"]
 MARKUP_SPECIFIC_CONTROLS: Final[Sequence[str]] = ["loop", "loop_index"]
 CONTROL_REGISTRY_PATH: Final[str] = str(
-    Path.PurePath(MODULE_PATH, "registry\\control_registry")
+    Path.PurePath(MODULE_PATH) / "registry" / "control_registry"
 )
 
 NULL: Final[str] = "<NULL>"


### PR DESCRIPTION
## How to Reproduce (macOS/Linux only)

```bash
python3 -c "from fjml.constants import CONTROL_REGISTRY_PATH; print(CONTROL_REGISTRY_PATH)"
```

On macOS/Linux the output contains a literal backslash in the filename:
```
/path/to/fjml/registry\control_registry   ← wrong
```
instead of:
```
/path/to/fjml/registry/control_registry   ← correct
```

You can also observe the failure functionally: any controls registered via `fjml registry add` are silently lost on every restart because the compiler always reads from the wrong path and gets an empty registry.

## Bug Explanation

In `src/fjml/constants.py`, the registry path was built using a hardcoded Windows backslash:

```python
# Before
CONTROL_REGISTRY_PATH: Final[str] = str(
    Path.PurePath(MODULE_PATH, "registry\\control_registry")
)
```

`"registry\\control_registry"` is a Python string containing a single backslash (`registry\control_registry`). On Windows, `PureWindowsPath` treats `\` as a path separator so this resolves correctly. On macOS/Linux, `PurePosixPath` only recognises `/` as a separator — backslash is just a regular character — so the entire `registry\control_registry` is treated as a single filename component, producing an invalid path.

The result: `RegistryFileOperations.load_file()` calls `os.path.exists()` on the wrong path, gets `False`, and creates a **new empty registry** at that wrong location. The `registry/control_registry` file that ships with the package (which contains built-in controls like `MatplotlibChart`, `PlotlyChart`, `colors`, and `icons`) is never found. This silently makes all built-in controls unavailable during compilation on any non-Windows system.

## Fix

Use pathlib's `/` operator for path joining, which handles separators correctly on all platforms:

```python
# After
CONTROL_REGISTRY_PATH: Final[str] = str(
    Path.PurePath(MODULE_PATH) / "registry" / "control_registry"
)
```

One line change, no behavioural impact on Windows, fixes the registry on macOS/Linux.