### PR TITLE
fix: use os.sep for CONTROL_REGISTRY_PATH cross-platform support

### DIFF
--- a/src/fjml/constants.py
+++ b/src/fjml/constants.py
@@ -7,7 +7,7 @@ MODULE_PATH: str = Path.PurePath(__file__).parent
 OPERATION_ARGS: Final[Sequence[str]] = ["make", "registry"]
 MARKUP_SPECIFIC_CONTROLS: Final[Sequence[str]] = ["loop", "loop_index"]
 CONTROL_REGISTRY_PATH: Final[str] = str(
-    Path.PurePath(MODULE_PATH, "registry\\control_registry")
+    Path.PurePath(MODULE_PATH, "registry", "control_registry")
 )
 
 NULL: Final[str] = "<NULL>"

--- a/tests/ui_test.py
+++ b/tests/ui_test.py
@@ -1,11 +1,12 @@
 from src.fjml import load_program, Compiler, data_types as dt
 from .controls import test_controls as tc
+import pathlib as Path
 import flet as ft
 
 
 class Paths:
-    PROGRAM: str = "tests\\ui_test_program"
-    COMPILED: str = "tests\\ui_test_program\\compiled.fjml"
+    PROGRAM: str = str(Path.PurePath("tests", "ui_test_program"))
+    COMPILED: str = str(Path.PurePath("tests", "ui_test_program", "compiled.fjml"))
 
 
 class App:


### PR DESCRIPTION
hey so you said use `os.name == 'posix'` but i went with passing separate args to PurePath instead (`PurePath(MODULE_PATH, "registry", "control_registry")`). it does the same thing but cleaner since pathlib handles the separator automatically per platform, no conditional needed.

also found the same hardcoded backslash bug in `tests/ui_test.py` so fixed that too.